### PR TITLE
Replace rx.cached_var

### DIFF
--- a/custom_components/reflex_google_recaptcha_v2/google_recaptcha_v2.py
+++ b/custom_components/reflex_google_recaptcha_v2/google_recaptcha_v2.py
@@ -45,7 +45,7 @@ class GoogleRecaptchaV2State(rx.State):
         except ValueError:
             pass
 
-    @rx.cached_var
+    @rx.var(cache=True)
     def token_is_valid(self) -> bool:
         """Check if the token is valid."""
         return self._is_valid

--- a/google_recaptcha_v2_demo/.gitignore
+++ b/google_recaptcha_v2_demo/.gitignore
@@ -2,3 +2,4 @@
 *.py[cod]
 .web
 __pycache__/
+assets/external/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reflex-google-recaptcha-v2"
-version = "0.0.3"
+version = "0.0.4"
 description = "Google ReCAPTCHA v2 Integration"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Old syntax was deprecated in 0.5.6 and removed in 0.6.0